### PR TITLE
App crashes on this line

### DIFF
--- a/SGURLProtocol/SGHTTPAuthenticationChallenge.m
+++ b/SGURLProtocol/SGHTTPAuthenticationChallenge.m
@@ -30,7 +30,10 @@
     // Fail if we can't retrieve decent protection space info
     CFArrayRef authenticationDomains = CFHTTPAuthenticationCopyDomains(_HTTPAuthentication);
     NSURL *URL = [(__bridge NSArray *)authenticationDomains lastObject];
-    CFRelease(authenticationDomains);
+    if(authenticationDomains)
+    {
+      CFRelease(authenticationDomains);
+    }
     
     if (!URL || ![URL host])
         return nil;


### PR DESCRIPTION
According to Apple documentation
"If CFRelease argument is NULL, this will cause a runtime error and your application will crash"
Adding check before releasing object.
